### PR TITLE
Use charAt instead of string array notation for ES3 browser support

### DIFF
--- a/stackframe.js
+++ b/stackframe.js
@@ -17,7 +17,7 @@
     }
 
     function _capitalize(str) {
-        return str[0].toUpperCase() + str.substring(1);
+        return str.charAt(0).toUpperCase() + str.substring(1);
     }
 
     function _getter(p) {


### PR DESCRIPTION
This PR changes string array access notation to use `charAt` in order to allow `stackframe` and dependent libraries to be loaded in very old ES3-only browsers (IE6/7).

This allows people to include stacktrace.js in apps/libraries that must support ancient browsers without a parse error.

Note: this is the only ES3 incompatible issue I found in `stackframe` and `stacktrace-parser`