### PR TITLE
Rewrite toString to match Node internals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage
 
 .idea
 .coveralls.yml
+dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,11 @@ addons:
     - google-chrome
     packages:
     - google-chrome-stable
+services:
+  - xvfb
 before_install:
 - export CHROME_BIN=chromium-browser
 - export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
 before_script:
 - npm install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: required
 dist: xenial
-node_js: stable
+node_js: 8
 addons:
   sauce_connect: true
   firefox: latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 sudo: required
-dist: trusty
+dist: xenial
 node_js: stable
 addons:
   sauce_connect: true

--- a/spec/stackframe-spec.js
+++ b/spec/stackframe-spec.js
@@ -158,8 +158,8 @@ describe('StackFrame', function() {
     });
 
     describe('#toString', function() {
-        it('represents empty StackFrame as "{anonymous}()"', function() {
-            expect(new StackFrame().toString()).toEqual('{anonymous}()');
+        it('represents empty StackFrame as "::"', function() {
+            expect(new StackFrame().toString()).toEqual('::');
         });
         it('represents complete StackFrame same as old stacktrace.js', function() {
             var unit = new StackFrame({
@@ -172,7 +172,7 @@ describe('StackFrame', function() {
                 isNative: false,
                 source: 'SOURCE'
             });
-            expect(unit.toString()).toEqual('fun(arg1,arg2)@http://site.com/path.js:1:4567');
+            expect(unit.toString()).toEqual('fun (http://site.com/path.js:1:4567)');
         });
     });
 });

--- a/stackframe.js
+++ b/stackframe.js
@@ -68,12 +68,20 @@
         },
 
         toString: function() {
-            var functionName = this.getFunctionName() || '{anonymous}';
-            var args = '(' + (this.getArgs() || []).join(',') + ')';
-            var fileName = this.getFileName() ? ('@' + this.getFileName()) : '';
-            var lineNumber = _isNumber(this.getLineNumber()) ? (':' + this.getLineNumber()) : '';
-            var columnNumber = _isNumber(this.getColumnNumber()) ? (':' + this.getColumnNumber()) : '';
-            return functionName + args + fileName + lineNumber + columnNumber;
+            var fileName = this.getFileName() || '';
+            var lineNumber = this.getLineNumber() || '';
+            var columnNumber = this.getColumnNumber() || '';
+            var functionName = this.getFunctionName() || '';
+            if (this.isEval()) {
+                if (fileName) {
+                    return '    at [eval] (' + fileName + ':' + lineNumber + ':' + columnNumber + ')';
+                }
+                return '    at [eval]:' + lineNumber + ':' + columnNumber;
+            }
+            if (functionName) {
+                return '    at ' + functionName + ' (' + fileName + ':' + lineNumber + ':' + columnNumber + ')';
+            }
+            return '    at ' + fileName + ':' + lineNumber + ':' + columnNumber;
         }
     };
 

--- a/stackframe.js
+++ b/stackframe.js
@@ -74,14 +74,14 @@
             var functionName = this.getFunctionName() || '';
             if (this.isEval()) {
                 if (fileName) {
-                    return '    at [eval] (' + fileName + ':' + lineNumber + ':' + columnNumber + ')';
+                    return '[eval] (' + fileName + ':' + lineNumber + ':' + columnNumber + ')';
                 }
-                return '    at [eval]:' + lineNumber + ':' + columnNumber;
+                return '[eval]:' + lineNumber + ':' + columnNumber;
             }
             if (functionName) {
-                return '    at ' + functionName + ' (' + fileName + ':' + lineNumber + ':' + columnNumber + ')';
+                return functionName + ' (' + fileName + ':' + lineNumber + ':' + columnNumber + ')';
             }
-            return '    at ' + fileName + ':' + lineNumber + ':' + columnNumber;
+            return fileName + ':' + lineNumber + ':' + columnNumber;
         }
     };
 

--- a/stackframe.js
+++ b/stackframe.js
@@ -72,7 +72,7 @@
             var lineNumber = this.getLineNumber() || '';
             var columnNumber = this.getColumnNumber() || '';
             var functionName = this.getFunctionName() || '';
-            if (this.isEval()) {
+            if (this.getIsEval()) {
                 if (fileName) {
                     return '[eval] (' + fileName + ':' + lineNumber + ':' + columnNumber + ')';
                 }


### PR DESCRIPTION
This closes #21 and #22, and rewrites the `toString` method to output a stack trace format that more closely resembles Node internals.

Ref: <https://github.com/nodejs/node/blob/b6bfc193788b1838bee73d584fe089e1104b9f88/src/node_errors.cc#L142-L175>